### PR TITLE
Upgrade cmr umm updater to 0.2.1

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -127,7 +127,7 @@ jobs:
           tag: ${{ env.software_version }}
           message: "Version ${{ env.software_version }}"
       - name: Publish UMM-S with new version
-        uses: podaac/cmr-umm-updater@0.1.1
+        uses: podaac/cmr-umm-updater@0.2.1
         if: |
           github.ref == 'refs/heads/main'    ||
           startsWith(github.ref, 'refs/heads/release')
@@ -136,6 +136,7 @@ jobs:
           provider: 'POCLOUD'
           env: ${{ env.venue }}
           version: ${{ env.software_version }}
+          timeout: 60
         env:
           cmr_user: ${{secrets.CMR_USER}}
           cmr_pass: ${{secrets.CMR_PASS}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Handle empty granule files.
   - [issue-14](https://github.com/podaac/concise/issues/14): Added support 
     for concatenating granules together that have different variables
+  - Added `timeout` option to `cmr-umm-updater`
 ### Changed 
+  - Upgraded `cmr-umm-updater` to 0.2.1
 ### Deprecated 
 ### Removed 
 ### Fixed 


### PR DESCRIPTION
Github Issue: n/a

### Description

Upgrade to the latest version of cmr-umm-updater, which uses Launchpad

### Overview of work done

- Update to cmr-umm-updater 0.2.1
- Add timeout option to cmr-umm-updater (60 seconds)

### Overview of verification done

n/a

### Overview of integration done

n/a

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [X] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_