### PR TITLE
feature/issue-31: Fix push tag github actions step 

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -118,14 +118,15 @@ jobs:
           git commit -am "/version ${{ env.software_version }}"
           git push
       - name: Push Tag
-        uses: actions-ecosystem/action-push-tag@v1
         if: |
           github.ref == 'refs/heads/develop' ||
           github.ref == 'refs/heads/main'    ||
           startsWith(github.ref, 'refs/heads/release')
-        with:
-          tag: ${{ env.software_version }}
-          message: "Version ${{ env.software_version }}"
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git tag -a "${{ env.software_version }}" -m "Version ${{ env.software_version }}"
+          git push origin "${{ env.software_version }}"
       - name: Publish UMM-S with new version
         uses: podaac/cmr-umm-updater@0.2.1
         if: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed 
 - Updated dependency versions
+- [issue-31](https://github.com/podaac/l2ss-py/issues/88): Build pipeline manually pushes tag rather than use action-push-tag
 ### Deprecated 
 ### Removed
 ### Fixed


### PR DESCRIPTION
Github Issue: #31

### Description

Fix failing build pipeline step. See https://github.com/podaac/l2ss-py/pull/91

### Overview of work done

Replaced github action actions-push-tag with manual tag push

### Overview of verification done

N/A

### Overview of integration done

N/A

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [X] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_