### PR TITLE
Issue #96: ensure the created dimension is sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed 
+  - [issues/96](https://github.com/podaac/concise/issues/96):
+    - impelemented sorting after [multi_core_download](https://github.com/podaac/concise/blob/23b44803f4829c1eb7e9d39b311a0373092daab3/podaac/merger/harmony/download_worker.py#L15) to preserve the input file order in the 
 ### Deprecated 
 ### Removed
 ### Fixed

--- a/podaac/merger/harmony/download_worker.py
+++ b/podaac/merger/harmony/download_worker.py
@@ -44,8 +44,8 @@ def multi_core_download(urls, destination_dir, access_token, cfg, process_count=
         url_queue = manager.Queue(len(urls))
         path_list = manager.list()
 
-        for url in urls:
-            url_queue.put(url)
+        for iurl, url in enumerate(urls):
+            url_queue.put((iurl, url))
 
         # Spawn worker processes
         processes = []
@@ -64,7 +64,7 @@ def multi_core_download(urls, destination_dir, access_token, cfg, process_count=
 
         path_list = deepcopy(path_list)  # ensure GC can cleanup multiprocessing
 
-    return [Path(path) for path in path_list]
+    return [Path(path) for ipath, path in sorted(path_list)]
 
 
 def _download_worker(url_queue, path_list, destination_dir, access_token, cfg):
@@ -91,7 +91,7 @@ def _download_worker(url_queue, path_list, destination_dir, access_token, cfg):
 
     while not url_queue.empty():
         try:
-            url = url_queue.get_nowait()
+            iurl, url = url_queue.get_nowait()
         except queue.Empty:
             break
 
@@ -105,4 +105,4 @@ def _download_worker(url_queue, path_list, destination_dir, access_token, cfg):
         else:
             logger.warning('Origin filename could not be assertained - %s', url)
 
-        path_list.append(str(path))
+        path_list.append((iurl, str(path)))


### PR DESCRIPTION
Github Issue: #96

### Description

The order of input files was not preserved in CONCISE. The [multi_core_download](https://github.com/podaac/concise/blob/23b44803f4829c1eb7e9d39b311a0373092daab3/podaac/merger/harmony/download_worker.py#L15) function was not sorting the returned list from [multiprocessing.Manager](https://github.com/podaac/concise/blob/23b44803f4829c1eb7e9d39b311a0373092daab3/podaac/merger/harmony/download_worker.py#L43). So the output order would be random.

### Overview of work done

- Added the order number to the [input queue](https://github.com/podaac/concise/blob/30fb9d4ab574d80d6f4879a6233f55573341f663/podaac/merger/harmony/download_worker.py#L47) for [multiprocessing.Manager](https://github.com/podaac/concise/blob/23b44803f4829c1eb7e9d39b311a0373092daab3/podaac/merger/harmony/download_worker.py#L43)
- Append the tuple of the order number and output filepath to the [multiprocessing output list](https://github.com/podaac/concise/blob/30fb9d4ab574d80d6f4879a6233f55573341f663/podaac/merger/harmony/download_worker.py#L108)
- Use the order number to [sort the files](https://github.com/podaac/concise/blob/30fb9d4ab574d80d6f4879a6233f55573341f663/podaac/merger/harmony/download_worker.py#L67) before the merge step

### Overview of verification done

- Built custom concise docker image with the implemented modifications and deployed it in the local harmony environment
- Ran multiple requests and compared the order of datafiles arriving at CONCISE input with the order of datafiles in the output merged file:

|**Comparison before sorting implemented shows that the order is not preserved**|**Comparison after sorting implemented shows that the order is preserved**|
|----------------|----------------|
|![image](https://github.com/podaac/concise/assets/154441323/feb82f93-7adf-4e7c-8af6-a2f17a3f6754)|![image](https://github.com/podaac/concise/assets/154441323/0e5d7457-30dc-493a-a1ec-d91946cbcb60)|
|![image](https://github.com/podaac/concise/assets/154441323/595e6626-6e0f-4003-955d-9f4f3455ec65)|![image](https://github.com/podaac/concise/assets/154441323/22141391-9bd5-4d60-b01a-46ca15225849)|




### Overview of integration done

See above

## PR checklist:

* [x] Linted (manually)
* [ N/A] Updated unit tests
* [x] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_
