### PR TITLE
add type annotations and args to docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
   - Updated python libraries
+  - [issue #114](https://github.com/podaac/concise/issues/114): add type annotations
 ### Deprecated
 ### Removed
   - Removed CMR testing.  Now done in [concise-autotest](https://github.com/podaac/concise-autotest) repo

--- a/podaac/merger/path_utils.py
+++ b/podaac/merger/path_utils.py
@@ -2,9 +2,10 @@
 Utilities used throughout the merging implementation to simplify group path resolution
 and generation
 """
+import netCDF4 as nc
 
 
-def get_group_path(group, resource):
+def get_group_path(group: nc.Group, resource: str) -> str:
     """
     Generates a Unix-like path from a group and resource to be accessed
 
@@ -27,7 +28,7 @@ def get_group_path(group, resource):
     return group.path + '/' + resource
 
 
-def resolve_group(dataset, path):
+def resolve_group(dataset: nc.Dataset, path: str):
     """
     Resolves a group path into two components: the group and the resource's name
 
@@ -50,10 +51,10 @@ def resolve_group(dataset, path):
     if len(components[0]) > 0:
         group = dataset[components[0]]
 
-    return (group, components[1])
+    return group, components[1]
 
 
-def resolve_dim(dims, group_path, dim_name):
+def resolve_dim(dims: dict, group_path: str, dim_name: str):
     """
     Attempt to resolve dim name starting from top-most group going down to the root group
 


### PR DESCRIPTION
Github Issue: #114 

### Description

This adds type annotations throughout `podaac.merger`, especially to clarify the usage of `pathlib.Path` instead of `str` for file paths.  It's not complete in adding all annotations, but brings up the level of annotations quite a bit.

### Overview of verification done

n/a

### Overview of integration done

n/a

## PR checklist:

* [x] Linted
* [n/a] Updated unit tests
* [x] Updated changelog
* [n/a] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_